### PR TITLE
DM-55493: collect changelog for 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Find changes for the upcoming release in the project's [changelog.d directory](h
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.2.1'></a>
+## 0.2.1 (2026-07-20)
+
+### Other changes
+
+- Update pinned dependencies and pre-commit hooks.
+
 <a id='changelog-0.2.0'></a>
 
 ## 0.2.0 (2025-05-06)

--- a/changelog.d/20260720_101813_jonathan_DM_55493_update.md
+++ b/changelog.d/20260720_101813_jonathan_DM_55493_update.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- Update pinned dependencies and pre-commit hooks.


### PR DESCRIPTION
## Summary

- Collect `changelog.d/` fragments into a new `0.2.1` `CHANGELOG.md` entry via scriv, ahead of tagging the 0.2.1 release.
- The only fragment present was for the already-merged monthly dependency refresh (#20): "Update pinned dependencies and pre-commit hooks."
- `_template.md.jinja` retained; the collected dated fragment was removed by `scriv collect`.

## Test plan

- [x] `uv run --group docs scriv collect --add --version 0.2.1` ran cleanly, producing a single coherent `0.2.1` entry in `CHANGELOG.md`.
- [x] Confirmed `changelog.d/` now only contains `_template.md.jinja`.
- [ ] Merge, then tag `0.2.1` and publish the GitHub release separately.

Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ