### PR TITLE
DM-55493: Refresh vendored ruff-shared.toml for ruff 0.16 CPY001

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ extend = "ruff-shared.toml"
 
 [tool.ruff.lint.isort]
 known-first-party = ["hoverdrive", "tests"]
-split-on-trailing-comma = false
 
 [tool.scriv]
 categories = [

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -36,6 +36,7 @@ ignore = [
     "ASYNC240", # we don't want to run filesystem operations on threads
     "BLE001",   # we want to catch and report Exception in background tasks
     "C414",     # nested sorted is how you sort by multiple keys with reverse
+    "CPY001",   # No, every single file doesn't need its own copyright notice
     "D102",     # sometimes we use docstring inheritence
     "D104",     # don't see the point of documenting every package
     "D105",     # our style doesn't require docstrings for magic methods


### PR DESCRIPTION
Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

## Summary
- ruff 0.16.0 stabilized `CPY001` (missing-copyright-notice) out of preview. Since `ruff-shared.toml` uses `select = ["ALL"]`, this rule armed itself fleet-wide.
- Synced `ruff-shared.toml` verbatim from `lsst/templates` `project_templates/fastapi_safir_app/{{cookiecutter.name}}/` (commit dd8e4b26), which adds `"CPY001"` to the `[lint] ignore` list.
- Pruned `split-on-trailing-comma = false` from `pyproject.toml` `[tool.ruff.lint.isort]` — now redundant with the refreshed shared value.

## Test plan
- [x] `ruff check .` — all checks pass

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ