### PR TITLE
DM-55493: Maintain uv version pins with update-uv-version.sh

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ env:
   # Current supported uv version. The uv documentation recommends pinning
   # this. The version should match the version used in .pre-commit-config.yaml
   # and frozen in uv.lock.
-  UV_VERSION: "0.7.2"
+  UV_VERSION: "0.11.33"
 
 "on":
   merge_group: {}

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -9,7 +9,7 @@ env:
   # Current supported uv version. The uv documentation recommends pinning
   # this. The version should match the version used in .pre-commit-config.yaml
   # and frozen in uv.lock.
-  UV_VERSION: "0.7.2"
+  UV_VERSION: "0.11.33"
 
 "on":
   schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 FROM base-image AS install-image
 
 # Install uv.
-COPY --from=ghcr.io/astral-sh/uv:0.7.2 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.33 /uv /bin/uv
 
 # Install some additional packages required for building dependencies.
 COPY scripts/install-dependency-packages.sh .

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,4 @@ update: update-deps init
 update-deps:
 	uv lock --upgrade
 	uv run --only-group=lint prek autoupdate
+	./scripts/update-uv-version.sh

--- a/scripts/update-uv-version.sh
+++ b/scripts/update-uv-version.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Update uv version references based on the frozen version from uv.lock.
+
+# Bash "strict mode", to help catch problems and bugs in the shell script.
+# Every bash script you write should include this. See
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
+set -euo pipefail
+
+# Expand non-matching globs to the empty list instead of the glob so that
+# packages that don't have one of the affected files can silently skip the
+# uv version rewrite rule that doesn't apply.
+shopt -s nullglob
+
+# Determine the current uv release version.
+uv_version=$(echo uv \
+             | uv pip compile - --quiet --no-header --no-annotate --no-config \
+             | sed -n 's/^uv==//p')
+
+# Replace the version in the env variables in GitHub Actions workflows.
+for f in .github/workflows/*.yaml; do
+    sed "s/UV_VERSION: .*/UV_VERSION: \"$uv_version\"/" "$f" >"$f.n"
+    if ! cmp -s "$f" "${f}.n"; then
+        echo "Updating UV_VERSION to $uv_version in $f"
+        mv "${f}.n" "$f"
+    else
+        rm "${f}.n"
+    fi
+done
+
+# Replace the version in any Dockerfiles. Allow for copying this script into
+# packages that have no Dockerfile.
+for f in Dockerfile*; do
+    sed "s/uv:[0-9][0-9.]*/uv:$uv_version/" "$f" >"${f}.n"
+    if ! cmp -s "$f" "${f}.n"; then
+        echo "Updating uv container version to $uv_version in $f"
+        mv "${f}.n" "$f"
+    else
+        rm "${f}.n"
+    fi
+done


### PR DESCRIPTION
Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

Applies the `uv-version-tooling` migration: installs `scripts/update-uv-version.sh` (copied verbatim from the `lsst/templates` `fastapi_safir_app` example) and wires it into `make update-deps` so the uv version pins stay current automatically going forward.

## Branch taken

3a — hoverdrive already had the `UV_VERSION` env var and `astral-sh/setup-uv` consumption wired into `.github/workflows/ci.yaml` (and also `periodic-ci.yaml`). No CI env/wiring changes were needed; only the version values were bumped by running the script.

## Version jump

- `Dockerfile` uv: `0.7.2` -> `0.11.33`
- `.github/workflows/ci.yaml` `UV_VERSION`: `0.7.2` -> `0.11.33`
- `.github/workflows/periodic-ci.yaml` `UV_VERSION`: `0.7.2` -> `0.11.33`

## Files the script rewrote

- `.github/workflows/ci.yaml`
- `.github/workflows/periodic-ci.yaml`
- `Dockerfile`

Verified idempotent (second run of the script produced no changes). `uv.lock` is untouched — this PR does not carry a dependency refresh. `tox -e lint` passes.

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ