### PR TITLE
DM-55688: Move dependabot to monthly grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,26 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+      time: "03:00"
+      timezone: "America/New_York"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+      time: "03:00"
+      timezone: "America/New_York"
+    groups:
+      docker:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
## Summary
- Switches both dependabot update entries (`github-actions`, `docker`) from weekly to monthly cadence, scheduled for 03:00 America/New_York.
- Adds wildcard `groups:` to each entry so all updates within an ecosystem land in a single grouped PR.
- Adds an `ignore` block on the `docker` entry blocking major/minor `python` base-image bumps (the Dockerfile pins `python:3.14.6-slim-bookworm`), consistent with how patch-only Python base image bumps are handled elsewhere in the fleet.

No `pip`/`uv` entries were added — `make update` covers lockfile upgrades for this repo per the migration playbook.

Jira: [DM-55688](https://rubinobs.atlassian.net/browse/DM-55688)

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` exits 0
- [x] No `weekly`/`daily` interval remains
- [x] `interval:` count matches `monthly` count
- [x] Every `updates:` entry has a `groups:` key
- [x] `github-actions` and `docker` entries present (Dockerfile exists at repo root); no npm lockfiles present so no `npm` entry needed

[DM-55688]: https://rubinobs.atlassian.net/browse/DM-55688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ