### PR TITLE
DM-55688: Fix pre-commit hook configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,14 @@ repos:
       - id: check-yaml
       - id: trailing-whitespace
 
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.11.33
+    hooks:
+      - id: uv-lock
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.22
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format


### PR DESCRIPTION
Two defects in `.pre-commit-config.yaml`, both of which made hoverdrive the odd one out among the fleet's FastAPI services.

## Use the `ruff-check` hook id

`astral-sh/ruff-pre-commit` renamed its `ruff` hook to `ruff-check`; the old id survives only as a deprecated alias. hoverdrive was the last service in the fleet still using it — everything else is already on `ruff-check`. Behavior is unchanged today, but the alias is on borrowed time.

## Add the `uv-lock` hook

hoverdrive was the only service missing `astral-sh/uv-pre-commit`. The `uv-lock` hook re-locks whenever `pyproject.toml` changes, so `uv.lock` can't silently drift out of sync with the declared dependencies — a drift that otherwise only surfaces later, in CI or in a resolution failure.

The `rev` is pinned to `0.11.33`, matching `UV_VERSION` in `ci.yaml`, per the fleet convention that keeps the CI env var, the pre-commit rev, and `uv.lock` on the same uv version.

## Validation

`uv run --only-group=lint prek run --all-files` passes on all six hooks. `uv-lock` reported no changes, confirming the committed `uv.lock` was already in sync — this PR touches only `.pre-commit-config.yaml`.

No changelog fragment: dev tooling only, ships no code, invisible to users.