### PR TITLE
DM-55688: Pin setup-uv to an exact version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
 
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
 

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           version: ${{ env.UV_VERSION }}
 


### PR DESCRIPTION
Jira: [DM-55688](https://rubinobs.atlassian.net/browse/DM-55688)

`astral-sh/setup-uv` has no floating major tag past `v7`, so the previous pin (`@v7`) could never be advanced by dependabot. Pins it to the current exact release, `astral-sh/setup-uv@v10.0.1`, in `ci.yaml` and `periodic-ci.yaml`.

Note: jumping v7 -> v10 inherits two upstream behavior changes, neither of which breaks a build and neither of which needs a workflow edit here: v9.0.0 changed `prune-cache` to default false, and v10.0.0 disables caching under the default `enable-cache: auto` for `pull_request_target` / `workflow_run` / `release` events. This repo's workflows don't trigger on `release:`, so that doesn't apply here.

CI-only change: ships no code, changes no image, no changelog fragment needed.

[DM-55688]: https://rubinobs.atlassian.net/browse/DM-55688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ