### PR TITLE
DM-55688: Move the base image to Debian trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #   - Runs as a non-root user.
 #   - Sets up the entrypoint and port.
 
-FROM python:3.14.6-slim-bookworm AS base-image
+FROM python:3.14.6-slim-trixie AS base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .


### PR DESCRIPTION
Moves the base image from `python:3.14.6-slim-bookworm` to `python:3.14.6-slim-trixie` across all Dockerfile stages (they all derive from `base-image`, so a single `FROM` line change covers the whole build).

Verified locally (not by CI, since PR CI only builds the image on ticket branches and does not run it):
- `docker build -t trixie-check .` completed successfully, including `install-base-packages.sh` and `install-dependency-packages.sh` on Debian 13.
- `docker run --rm trixie-check python -c "import sys; print(sys.version)"` printed `3.14.6 (main, Aug  5 2026, 01:11:00) [GCC 14.2.0]`.

No changelog fragment added — the prior base-image bump (60235d2) did not add one either.

Jira: [DM-55688](https://rubinobs.atlassian.net/browse/DM-55688)

[DM-55688]: https://rubinobs.atlassian.net/browse/DM-55688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ