### PR TITLE
DM-55688: Build multiplatform images on release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,8 @@ env:
       - "renovate/**"
       - "tickets/**"
       - "u/**"
-    tags:
-      - "*"
+  release:
+    types: [published]
 
 jobs:
   lint:
@@ -65,27 +65,17 @@ jobs:
         run: uv run --only-group=tox tox run -e py,coverage-report
 
   build:
-    runs-on: ubuntu-latest
+    concurrency:
+      group: docker
+      queue: max
     needs: [lint, test]
-    timeout-minutes: 10
+    secrets: inherit
+    uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v4
+    with:
+      images: ghcr.io/${{ github.repository }}
 
-    # Only do Docker builds of tagged releases and pull requests from ticket
-    # branches.  This will still trigger on pull requests from untrusted
-    # repositories whose branch names match our tickets/* branch convention,
-    # but in this case the build will fail with an error since the secret
-    # won't be set.
     if: >
-      github.event_name != 'merge_group'
-      && (startsWith(github.ref, 'refs/tags/')
-          || startsWith(github.head_ref, 'tickets/'))
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - uses: lsst-sqre/build-and-push-to-ghcr@v1
-        id: build
-        with:
-          image: ${{ github.repository }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      (github.event_name == 'release' && github.event.action == 'published')
+      || (github.event_name != 'merge_group'
+          && (startsWith(github.head_ref, 'tickets/')
+              || startsWith(github.head_ref, 't/')))


### PR DESCRIPTION
## Summary

Jira: [DM-55688](https://rubinobs.atlassian.net/browse/DM-55688)

Switches hoverdrive's Docker build job from the tag-triggered, single-arch
`build-and-push-to-ghcr@v1` step to the `multiplatform-build-and-push`
reusable workflow, triggered on published GitHub releases instead of pushed
tags. Matches the shape already in use across the other nine compliant
repos.

- `"on":` block: dropped the `tags:` list under `push:`, added a `release:
  types: [published]` trigger.
- `build:` job: replaced the inline job with a call to
  `lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v4`,
  `secrets: inherit`, `needs: [lint, test]`, and the same `concurrency:
  {group: docker, queue: max}` used by the ghcr-cleanup job so a prune never
  races a build.

## Important: PR CI does not prove this works

The build job only runs for `tickets/`/`t/` head refs and for published
releases. This PR (branched off `tickets/`) exercises the *build* path, but
the *release* trigger cannot be exercised until the next release is cut.

**The real verification is the first post-merge release.** After that
release publishes, check that the resulting image manifest actually has
both architectures:

```
docker manifest inspect ghcr.io/lsst-sqre/hoverdrive:<version>
```

## Test plan

- [x] YAML parses and has the expected shape (`release` trigger present,
      `tags` removed from `push`, `build` job uses the reusable workflow,
      `concurrency.group == docker`)
- [x] Diff touches exactly `.github/workflows/ci.yaml`
- [ ] Post-merge: cut a release and confirm `docker manifest inspect
      ghcr.io/lsst-sqre/hoverdrive:<version>` shows both architectures

[DM-55688]: https://rubinobs.atlassian.net/browse/DM-55688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ