### PR TITLE
DM-55688: Report build / manifest on dependabot PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,9 +73,20 @@ jobs:
     uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v4
     with:
       images: ghcr.io/${{ github.repository }}
+      # Build but don't push for dependabot PRs: no registry secrets are
+      # available and we don't want dependency-bump images in the registry.
+      push: >-
+        ${{ (github.event_name == 'release' && github.event.action == 'published')
+            || startsWith(github.head_ref, 'tickets/')
+            || startsWith(github.head_ref, 't/') }}
 
+    # Build on releases, ticket-branch PRs (build + push), and dependabot PRs
+    # (build only) so the required "build / manifest" check is reported. A
+    # skipped job reports no check at all, which leaves the required check
+    # waiting forever.
     if: >
       (github.event_name == 'release' && github.event.action == 'published')
       || (github.event_name != 'merge_group'
           && (startsWith(github.head_ref, 'tickets/')
-              || startsWith(github.head_ref, 't/')))
+              || startsWith(github.head_ref, 't/')
+              || startsWith(github.head_ref, 'dependabot/')))


### PR DESCRIPTION
## Summary

The required status check on this repo is `build / manifest`, which the
reusable build workflow only reports when its job actually runs. The job-level
`if:` skipped the job for any head ref outside `tickets/` and `t/`, and a
skipped job creates no check-run at all — so every dependabot PR sat waiting on
a check that would never arrive and could not merge.

This lets dependabot PRs into the job so the check reports, and excludes them
from the `push:` input so no dependency-bump image reaches the registry (there
are no registry secrets on those PRs anyway).

This is the shape squarebot, templatebot and unfurlbot already use; docverse
solves the same problem by dropping the job-level `if:` entirely and gating
only on `push:`.

## Context

Fallout from DM-55688's move to the multiplatform reusable workflow, which
renamed the check from `build` to `build / manifest`. The ruleset was updated to
match, which is what armed this: with the old inline job the check was never
required under its new name.

## Validation

- `ci.yaml` parses; the build job keeps `concurrency: {group: docker, queue: max}`
  and its `release` trigger.
- The `if:` now admits `tickets/`, `t/` and `dependabot/`; the `push:` input
  admits `tickets/` and `t/` only.
- The real check is this PR's own open dependabot PR going green afterwards:
  hoverdrive#26. This PR is itself on a `tickets/` branch,
  so it exercises the build-and-push path, not the new dependabot path.

Jira: DM-55688
