### PR TITLE
DM-55688: Honour t/ branches and serialize image builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ env:
       - "dependabot/**"
       - "gh-readonly-queue/**"
       - "renovate/**"
+      - "t/**"
       - "tickets/**"
       - "u/**"
   release:


### PR DESCRIPTION
Adds `t/**` to the `push.branches-ignore` list so `t/`-prefixed branches don't double-trigger CI via the push trigger (the pull_request trigger already covers them). This repo already has the `t/` build gate and `docker`/`queue: max` concurrency block from an earlier campaign, so this PR is a one-line addition to close the remaining gap.

Jira: DM-55688

Note: this PR itself is opened from a `tickets/` branch, so it doesn't exercise the new `t/` push-trigger path — the first `t/` branch pushed after merge is the real check.