### PR TITLE
DM-55688: Add weekly GHCR cleanup workflow

### DIFF
--- a/.github/workflows/ghcr-cleanup.yaml
+++ b/.github/workflows/ghcr-cleanup.yaml
@@ -1,0 +1,37 @@
+# Prune unreferenced Docker images and ticket branches from more than six
+# months ago, weekly on Monday.
+
+name: GHCR Cleanup
+
+"on":
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    concurrency:
+      group: docker
+      queue: max
+
+    steps:
+      - uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          delete-orphaned-images: true
+          delete-tags: "tickets-*,t-*"
+          delete-untagged: true
+          older-than: "6 months"
+          validate: true
+
+      - name: Report status
+        if: failure()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "GHCR cleanup for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}


### PR DESCRIPTION
Adds `.github/workflows/ghcr-cleanup.yaml`, the canonical weekly GHCR cleanup workflow from `lsst/templates` (`fastapi_safir_app` template), which prunes unreferenced Docker images and stale ticket-branch tags older than six months, weekly on Monday.

**Case:** ABSENT — hoverdrive had no `ghcr-cleanup.yaml` before this PR, so this is a single new file installed verbatim from the template's rendered output.

**Note on CI:** the workflow's own triggers are `schedule` and `workflow_dispatch` only, so PR CI cannot exercise it — the first real run happens after merge, either on the Monday cron or via a manual `workflow_dispatch` from the default branch. A green PR here says nothing about the job actually working.

Jira: [DM-55688](https://rubinobs.atlassian.net/browse/DM-55688)

[DM-55688]: https://rubinobs.atlassian.net/browse/DM-55688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ