### PR TITLE
DM-55688: Always run the build job so build / manifest reports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,20 +74,13 @@ jobs:
     uses: lsst-sqre/multiplatform-build-and-push/.github/workflows/build.yaml@v4
     with:
       images: ghcr.io/${{ github.repository }}
-      # Build but don't push for dependabot PRs: no registry secrets are
-      # available and we don't want dependency-bump images in the registry.
+      # Always build so the required `build / manifest` check reports on
+      # every PR: a job skipped by its own `if:` creates no check-run at
+      # all, and the required check hangs in "Expected" forever. Only push
+      # on releases and ticket-branch PRs -- every other branch (u/,
+      # dependabot/, renovate/, forks) builds as validation, and the
+      # manifest job skips, which counts as passing.
       push: >-
         ${{ (github.event_name == 'release' && github.event.action == 'published')
             || startsWith(github.head_ref, 'tickets/')
             || startsWith(github.head_ref, 't/') }}
-
-    # Build on releases, ticket-branch PRs (build + push), and dependabot PRs
-    # (build only) so the required "build / manifest" check is reported. A
-    # skipped job reports no check at all, which leaves the required check
-    # waiting forever.
-    if: >
-      (github.event_name == 'release' && github.event.action == 'published')
-      || (github.event_name != 'merge_group'
-          && (startsWith(github.head_ref, 'tickets/')
-              || startsWith(github.head_ref, 't/')
-              || startsWith(github.head_ref, 'dependabot/')))


### PR DESCRIPTION
Jira: [DM-55688](https://rubinobs.atlassian.net/browse/DM-55688)

Removes the build job's `if:` gate. A job skipped by its own `if:` creates no check-run at all, which leaves a required `build / manifest` check hanging in "Expected" forever for any PR not on a `tickets/` or `t/` branch. The existing `push:` gate is unchanged and still controls whether the built image is pushed to the registry (releases and ticket-branch PRs only); every other branch now builds as validation and the manifest job simply skips, which counts as passing.

This PR itself rides a `tickets/` branch, so it exercises the build-**and-push** path. The real verification is the repo's next `u/` or `dependabot/` PR showing `build / manifest` as a completed (built, unpushed) check instead of hanging in "Expected".

Not merging this PR as part of applying the migration.

[DM-55688]: https://rubinobs.atlassian.net/browse/DM-55688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ